### PR TITLE
Add unova/lyric-decipher: multi-pass lyric transcription pack

### DIFF
--- a/unova/lyric-decipher/README.md
+++ b/unova/lyric-decipher/README.md
@@ -1,0 +1,105 @@
+# UNOVA Lyric Decipher
+
+A local bot for deciphering lyrics that are genuinely hard to hear and not
+published anywhere — mumbled vocals, tiny artists, unreleased mixes.
+
+It takes an audio file you already have, checks whether the lyrics are in fact
+already published (LRCLIB), and if not, runs a multi-pass transcription
+pipeline that is honest about uncertainty: every word the passes disagreed on
+is flagged with a timestamp and the alternatives, so you ear-check seconds,
+not the whole song.
+
+## How it works
+
+1. **Metadata** — paste a Spotify track link and the pack resolves the display
+   title via the public oEmbed endpoint (no login, no audio). Or pass
+   `--title/--artist` yourself.
+2. **Published-lyrics check** — searches LRCLIB, the open lyrics database. If
+   someone already transcribed the song, that's saved as `reference.*` and you
+   just saved yourself the work.
+3. **Audio variants** — ffmpeg decodes the file and builds a vocal-focused
+   variant (center-channel extraction + voice band-pass + gentle compression).
+   With `--demucs` installed you also get a true ML vocal stem.
+4. **Multi-pass Whisper** — each variant is transcribed with word-level
+   timestamps; the best variant gets extra decode configs (different beam
+   sizes / temperatures). Sung vocals make ASR fail in *different* places per
+   pass, which is exactly the signal we want.
+5. **Consensus** — the strongest pass provides the structure; every word is
+   cross-checked against the other passes by time overlap. Confident + agreed
+   words are trusted; the rest are marked `[like this?]` with alternatives in
+   the report.
+
+## Setup (macOS)
+
+```bash
+brew install ffmpeg
+pip install -r unova/lyric-decipher/requirements.txt
+```
+
+Optional, best vocal isolation for dense mixes (pulls PyTorch):
+
+```bash
+pip install demucs
+```
+
+## Usage
+
+```bash
+# the track that started this pack — him's "Chateau (elan)":
+python3 unova/lyric-decipher/decipher.py ~/Music/chateau-elan.m4a \
+  --spotify-url "https://open.spotify.com/track/7ewmdNM0LTB9MMomRmtFQY" \
+  --artist "him's"
+
+# quick check whether lyrics are already published, no transcription:
+python3 unova/lyric-decipher/decipher.py --lookup-only --title "Chateau (elan)" --artist "him's"
+
+# harder mixes: bigger model + vocal stem + a genre hint for the decoder
+python3 unova/lyric-decipher/decipher.py song.flac --model medium --demucs \
+  --prompt "indie bedroom pop, hushed male vocal"
+```
+
+Useful flags: `--language en` when autodetect guesses wrong, `--model`
+(`tiny`→`large-v3`; `small` is the speed/quality sweet spot on CPU),
+`--extra-passes 0` for a fast single-config run, `--no-enhance`,
+`--skip-lookup`. Defaults can live in `config.json` (copy
+`config.example.json`).
+
+## Outputs
+
+Each run lands in `unova/lyric-decipher/runs/<timestamp>-<slug>/` (with a
+`latest` symlink):
+
+- `lyrics.txt` — reading copy, uncertain words marked `[word?]`
+- `lyrics.lrc` — synced lyrics for players that scroll
+- `lyrics.srt` — load next to the audio in a video player to ear-check
+  flagged moments at the exact second
+- `report.md` — review sheet: pass table, and every flagged word with its
+  timestamp, confidence, agreement, and what other passes heard
+- `report.json` — every pass, line, word, and probability, machine-readable
+- `reference.txt` / `reference.lrc` — only when published lyrics were found
+
+The intended loop: run the pack, open `report.md`, ear-check the handful of
+flagged timestamps with `lyrics.srt` loaded in a player, correct
+`lyrics.txt`, done.
+
+## Scope and sources
+
+- Works on audio files you already have: purchases, DRM-free downloads
+  (Bandcamp etc.), your own recordings. It does **not** download audio from
+  Spotify or other streaming services — the Spotify link is used only to
+  resolve the track title.
+- Output is for your own listening/reference. Deciphered transcriptions of
+  someone else's song aren't yours to republish.
+
+## Smoke test
+
+`smoke/run_smoke.sh` synthesizes a fake "song" (espeak-ng vocal over a
+generated instrumental bed), runs the full pipeline on it with the `tiny`
+model, and checks that known words come through. Needs ffmpeg + espeak-ng +
+faster-whisper; first run downloads the tiny model (~75 MB).
+
+Offline unit tests (no model, no network):
+
+```bash
+python3 -m pytest unova/lyric-decipher/tests
+```

--- a/unova/lyric-decipher/config.example.json
+++ b/unova/lyric-decipher/config.example.json
@@ -1,0 +1,10 @@
+{
+  "model": "small",
+  "language": null,
+  "extra_passes": 2,
+  "enhance": true,
+  "demucs": false,
+  "prompt": null,
+  "device": "auto",
+  "compute_type": "auto"
+}

--- a/unova/lyric-decipher/decipher.py
+++ b/unova/lyric-decipher/decipher.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Launcher so the pack runs from anywhere: python3 unova/lyric-decipher/decipher.py …"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lyric_decipher.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unova/lyric-decipher/lyric_decipher/__init__.py
+++ b/unova/lyric-decipher/lyric_decipher/__init__.py
@@ -1,0 +1,3 @@
+"""UNOVA Lyric Decipher: multi-pass lyric transcription for hard-to-hear vocals."""
+
+__version__ = "0.1.0"

--- a/unova/lyric-decipher/lyric_decipher/audio.py
+++ b/unova/lyric-decipher/lyric_decipher/audio.py
@@ -1,0 +1,170 @@
+"""Audio preparation: decode, vocal-focused enhancement, optional stem split.
+
+Everything funnels through ffmpeg so any input container/codec works. Each
+prepared variant is a 16 kHz mono WAV, which is what Whisper-family models
+expect.
+
+Variants, cheapest first:
+
+- "original": plain decode. Baseline pass; sometimes the model does better
+  with full-band context than with any filtering.
+- "enhanced": a vocal-intelligibility filter chain. Pop vocals sit in the
+  stereo center and in the 150 Hz–5 kHz band, so mid extraction + band-pass +
+  gentle multiband compression lifts the voice against the instrumental
+  without any ML dependency.
+- "vocals": Demucs stem separation, only when the `demucs` CLI is installed
+  (it drags in PyTorch, so it stays optional). Best quality on dense mixes.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+SAMPLE_RATE = 16_000
+
+# Mid (center) extraction keeps what L and R share — normally the lead vocal —
+# then band-pass to the voice range and even out the dynamics so quiet
+# syllables survive. compand is deliberately gentle: over-compression smears
+# consonants, which is exactly what we cannot afford here.
+ENHANCE_FILTER = (
+    "aformat=channel_layouts=stereo,"
+    "pan=mono|c0=0.5*FL+0.5*FR,"
+    "highpass=f=120,lowpass=f=5500,"
+    "compand=attacks=0.02:decays=0.25:points=-70/-70|-35/-20|-20/-12|0/-6,"
+    "loudnorm=I=-19:TP=-2:LRA=9"
+)
+
+
+class AudioPrepError(RuntimeError):
+    pass
+
+
+@dataclass
+class AudioVariant:
+    name: str
+    path: Path
+    description: str
+
+
+def _run(cmd: list[str]) -> None:
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        tail = "\n".join(proc.stderr.strip().splitlines()[-8:])
+        raise AudioPrepError(f"command failed: {' '.join(cmd[:3])} …\n{tail}")
+
+
+def ffmpeg_available() -> bool:
+    return shutil.which("ffmpeg") is not None
+
+
+def demucs_available() -> bool:
+    return shutil.which("demucs") is not None
+
+
+def probe_duration(path: Path) -> float | None:
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        return None
+    proc = subprocess.run(
+        [
+            ffprobe,
+            "-v", "error",
+            "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    try:
+        return float(proc.stdout.strip())
+    except ValueError:
+        return None
+
+
+def prepare_variants(
+    source: Path,
+    workdir: Path,
+    *,
+    enhance: bool = True,
+    use_demucs: bool = False,
+) -> list[AudioVariant]:
+    """Decode `source` into one or more 16 kHz mono WAV variants under `workdir`."""
+    if not ffmpeg_available():
+        raise AudioPrepError(
+            "ffmpeg is required. Install it first (macOS: `brew install ffmpeg`)."
+        )
+    if not source.exists():
+        raise AudioPrepError(f"audio file not found: {source}")
+    workdir.mkdir(parents=True, exist_ok=True)
+    variants: list[AudioVariant] = []
+
+    original = workdir / "original.wav"
+    _run(
+        [
+            "ffmpeg", "-y", "-v", "error",
+            "-i", str(source),
+            "-ac", "1", "-ar", str(SAMPLE_RATE),
+            str(original),
+        ]
+    )
+    variants.append(AudioVariant("original", original, "plain 16 kHz mono decode"))
+
+    if enhance:
+        enhanced = workdir / "enhanced.wav"
+        _run(
+            [
+                "ffmpeg", "-y", "-v", "error",
+                "-i", str(source),
+                "-af", ENHANCE_FILTER,
+                "-ar", str(SAMPLE_RATE),
+                str(enhanced),
+            ]
+        )
+        variants.append(
+            AudioVariant(
+                "enhanced",
+                enhanced,
+                "center-channel extraction + voice band-pass + gentle compression",
+            )
+        )
+
+    if use_demucs:
+        if not demucs_available():
+            raise AudioPrepError(
+                "demucs was requested but the `demucs` CLI is not installed. "
+                "Install with `pip install demucs` (pulls PyTorch) or drop --demucs."
+            )
+        vocals = _demucs_vocals(source, workdir)
+        variants.append(AudioVariant("vocals", vocals, "Demucs two-stem vocal isolate"))
+
+    return variants
+
+
+def _demucs_vocals(source: Path, workdir: Path) -> Path:
+    with tempfile.TemporaryDirectory(dir=workdir) as tmp:
+        _run(
+            [
+                "demucs",
+                "--two-stems", "vocals",
+                "-o", tmp,
+                str(source),
+            ]
+        )
+        hits = sorted(Path(tmp).rglob("vocals.wav"))
+        if not hits:
+            raise AudioPrepError("demucs finished but produced no vocals.wav")
+        out = workdir / "vocals.wav"
+        _run(
+            [
+                "ffmpeg", "-y", "-v", "error",
+                "-i", str(hits[0]),
+                "-ac", "1", "-ar", str(SAMPLE_RATE),
+                str(out),
+            ]
+        )
+    return out

--- a/unova/lyric-decipher/lyric_decipher/cli.py
+++ b/unova/lyric-decipher/lyric_decipher/cli.py
@@ -1,0 +1,189 @@
+"""Command-line entry point.
+
+    python3 decipher.py song.m4a --spotify-url https://open.spotify.com/track/…
+
+Works on a local audio file you already have (purchase, DRM-free download,
+your own recording). It never downloads audio from streaming services.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+from . import __version__
+from .audio import AudioPrepError, prepare_variants, probe_duration
+from .consensus import build_consensus
+from .metadata import TrackInfo, lookup_published_lyrics, resolve_spotify_track
+from .output import make_run_dir, write_outputs, write_reference_only
+from .transcribe import run_passes, save_pass_audio_note
+
+PACK_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_config(path: Path | None) -> dict:
+    candidates = [path] if path else [PACK_ROOT / "config.json"]
+    for cand in candidates:
+        if cand and cand.exists():
+            try:
+                return json.loads(cand.read_text())
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"config {cand} is not valid JSON: {exc}")
+    return {}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="lyric-decipher",
+        description="Decipher hard-to-hear lyrics from an audio file you already have.",
+    )
+    p.add_argument("audio", nargs="?", type=Path, help="path to the audio file")
+    p.add_argument("--spotify-url", help="Spotify track link, used only to resolve title metadata")
+    p.add_argument("--title", help="track title (overrides anything resolved)")
+    p.add_argument("--artist", help="artist name (overrides anything resolved)")
+    p.add_argument("--language", help="ISO language hint, e.g. en, ja (default: autodetect)")
+    p.add_argument("--model", help="Whisper size: tiny/base/small/medium/large-v3 (default small)")
+    p.add_argument("--extra-passes", type=int, default=None,
+                   help="extra decode configs on the best variant, 0-2 (default 2)")
+    p.add_argument("--prompt", help="style/vocabulary hint passed to the model "
+                                    "(e.g. song genre, artist spellings)")
+    p.add_argument("--no-enhance", action="store_true", help="skip the vocal-focus filter variant")
+    p.add_argument("--demucs", action="store_true",
+                   help="add a Demucs vocal-stem variant (requires `pip install demucs`)")
+    p.add_argument("--skip-lookup", action="store_true",
+                   help="don't check LRCLIB for already-published lyrics")
+    p.add_argument("--lookup-only", action="store_true",
+                   help="only check for published lyrics; no transcription")
+    p.add_argument("--config", type=Path, help="path to config.json (default: pack root)")
+    p.add_argument("--out-root", type=Path, help="where runs/ lives (default: this pack)")
+    p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    cfg = load_config(args.config)
+
+    model_size = args.model or cfg.get("model", "small")
+    extra = args.extra_passes if args.extra_passes is not None else int(cfg.get("extra_passes", 2))
+    language = args.language or cfg.get("language")
+    enhance = not args.no_enhance and cfg.get("enhance", True)
+    use_demucs = args.demucs or bool(cfg.get("demucs", False))
+    pack_root = args.out_root or Path(cfg.get("out_root", PACK_ROOT))
+
+    # --- metadata -----------------------------------------------------------
+    track = TrackInfo()
+    if args.spotify_url:
+        resolved = resolve_spotify_track(args.spotify_url)
+        if resolved:
+            track = resolved
+            print(f"resolved track: {track.display()}")
+        else:
+            print("warning: could not resolve the Spotify link; continuing without it",
+                  file=sys.stderr)
+            track.spotify_url = args.spotify_url
+    if args.title:
+        track.title = args.title
+    if args.artist:
+        track.artist = args.artist
+    if not track.title and args.audio is not None:
+        track.title = args.audio.stem
+
+    # --- published-lyrics check --------------------------------------------
+    reference = None
+    if not args.skip_lookup and track.title:
+        reference = lookup_published_lyrics(track)
+        if reference:
+            who = reference.detail.get("artistName") or "?"
+            what = reference.detail.get("trackName") or track.title
+            print(f"published lyrics found on LRCLIB: “{what}” by {who} — saving as reference")
+            if reference.instrumental:
+                print("note: LRCLIB marks this track as instrumental")
+        else:
+            print("no published lyrics found — deciphering from audio")
+
+    if args.lookup_only:
+        if not reference:
+            print("lookup-only: nothing published for this track; run again with an "
+                  "audio file to transcribe it")
+            return 1
+        run_dir = make_run_dir(pack_root, track.slug())
+        write_reference_only(run_dir, track, reference)
+        print(f"reference lyrics saved under {run_dir}")
+        return 0
+
+    # --- transcription ------------------------------------------------------
+    if args.audio is None:
+        print("error: an audio file is required unless --lookup-only is used", file=sys.stderr)
+        return 2
+    if not args.audio.exists():
+        print(f"error: audio file not found: {args.audio}", file=sys.stderr)
+        return 2
+
+    duration = probe_duration(args.audio)
+    if duration:
+        print(f"audio: {args.audio.name} ({duration:.0f}s)")
+
+    with tempfile.TemporaryDirectory(prefix="lyric-decipher-") as tmp:
+        try:
+            variants = prepare_variants(
+                args.audio, Path(tmp), enhance=enhance, use_demucs=use_demucs
+            )
+        except AudioPrepError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        print("prepared variants: " + ", ".join(v.name for v in variants))
+
+        passes = run_passes(
+            variants,
+            model_size=model_size,
+            language=language,
+            extra_configs=extra,
+            initial_prompt=args.prompt or cfg.get("prompt"),
+            device=cfg.get("device", "auto"),
+            compute_type=cfg.get("compute_type", "auto"),
+            progress=lambda msg: print(f"  {msg}"),
+        )
+        audio_notes = save_pass_audio_note(variants)
+
+    non_empty = [p for p in passes if p.words]
+    if not non_empty:
+        print("error: no pass produced any words — is there singing in this file? "
+              "Try --model medium, or --demucs for a dense mix.", file=sys.stderr)
+        return 1
+
+    consensus = build_consensus(non_empty)
+    run_dir = make_run_dir(pack_root, track.slug())
+    written = write_outputs(
+        run_dir,
+        track,
+        consensus,
+        reference,
+        audio_notes=audio_notes,
+        settings={
+            "model": model_size,
+            "language": language or "auto",
+            "extra_passes": extra,
+            "enhance": enhance,
+            "demucs": use_demucs,
+            "version": __version__,
+        },
+    )
+
+    flagged = consensus.flagged_words()
+    print()
+    print(f"deciphered {len(consensus.words)} words across {len(consensus.lines)} lines "
+          f"· overall confidence {consensus.overall_confidence():.0%}")
+    if flagged:
+        print(f"{len(flagged)} word(s) need an ear-check — see report.md")
+    print("outputs:")
+    for name, path in written.items():
+        print(f"  {name}: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unova/lyric-decipher/lyric_decipher/consensus.py
+++ b/unova/lyric-decipher/lyric_decipher/consensus.py
@@ -1,0 +1,140 @@
+"""Cross-pass consensus: agree where passes agree, flag where they don't.
+
+The primary pass (highest duration-weighted word probability) provides the
+line structure and timing. Every primary word is then checked against the
+other passes by time overlap:
+
+- words the model was sure of AND other passes reproduced → trusted
+- everything else → flagged, with the alternatives the other passes heard,
+  so a human can ear-check exactly that second of audio instead of
+  re-listening to the whole song.
+
+This never invents text: the output is always something a pass actually
+heard, annotated with how much to trust it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from .transcribe import PassResult, Word
+
+PROB_FLOOR = 0.45        # model-confidence floor before a word gets flagged
+AGREEMENT_FLOOR = 0.5    # fraction of comparison passes that must agree
+OVERLAP_SLACK = 0.25     # seconds of timing slack when matching words across passes
+
+
+def normalize_word(text: str) -> str:
+    return re.sub(r"[^\w']+", "", text.lower()).strip("'")
+
+
+@dataclass
+class ConsensusWord:
+    word: Word
+    agreement: float          # 0..1 across passes that had a word here; 1.0 if unopposed
+    votes: int                # passes with any overlapping word
+    flagged: bool
+    alternatives: list[tuple[str, int]] = field(default_factory=list)
+
+
+@dataclass
+class ConsensusLine:
+    start: float
+    end: float
+    words: list[ConsensusWord]
+
+    @property
+    def text(self) -> str:
+        return " ".join(cw.word.text for cw in self.words)
+
+    def marked_text(self) -> str:
+        parts = []
+        for cw in self.words:
+            parts.append(f"[{cw.word.text}?]" if cw.flagged else cw.word.text)
+        return " ".join(parts)
+
+
+@dataclass
+class ConsensusResult:
+    primary: str
+    lines: list[ConsensusLine]
+    passes: list[PassResult]
+
+    @property
+    def words(self) -> list[ConsensusWord]:
+        return [w for line in self.lines for w in line.words]
+
+    def flagged_words(self) -> list[ConsensusWord]:
+        return [w for w in self.words if w.flagged]
+
+    def overall_confidence(self) -> float:
+        words = self.words
+        if not words:
+            return 0.0
+        return sum(cw.word.prob * (0.5 + 0.5 * cw.agreement) for cw in words) / len(words)
+
+
+def _overlapping(word: Word, candidates: list[Word]) -> Word | None:
+    """Best time-overlapping candidate for `word`, or None."""
+    best: Word | None = None
+    best_overlap = 0.0
+    lo, hi = word.start - OVERLAP_SLACK, word.end + OVERLAP_SLACK
+    for cand in candidates:
+        if cand.end < lo or cand.start > hi:
+            continue
+        overlap = min(word.end, cand.end) - max(word.start, cand.start)
+        # midpoint containment rescues zero-duration overlaps within the slack
+        if overlap <= 0 and not (lo <= cand.mid <= hi):
+            continue
+        if overlap > best_overlap or best is None:
+            best, best_overlap = cand, max(overlap, 0.0)
+    return best
+
+
+def build_consensus(passes: list[PassResult]) -> ConsensusResult:
+    if not passes:
+        raise ValueError("no transcription passes to merge")
+    ranked = sorted(passes, key=lambda p: p.score(), reverse=True)
+    primary = ranked[0]
+    others = ranked[1:]
+    other_words = [p.words for p in others]
+
+    lines: list[ConsensusLine] = []
+    for line in primary.lines:
+        cwords: list[ConsensusWord] = []
+        for word in line.words:
+            norm = normalize_word(word.text)
+            votes = 0
+            agree = 0
+            alt_counts: dict[str, int] = {}
+            alt_display: dict[str, str] = {}
+            for pool in other_words:
+                match = _overlapping(word, pool)
+                if match is None:
+                    continue
+                votes += 1
+                match_norm = normalize_word(match.text)
+                if match_norm == norm:
+                    agree += 1
+                elif match_norm:
+                    alt_counts[match_norm] = alt_counts.get(match_norm, 0) + 1
+                    alt_display.setdefault(match_norm, match.text)
+            agreement = agree / votes if votes else 1.0
+            flagged = bool(word.prob < PROB_FLOOR or (votes > 0 and agreement < AGREEMENT_FLOOR))
+            alternatives = sorted(
+                ((alt_display[k], n) for k, n in alt_counts.items()),
+                key=lambda kv: (-kv[1], kv[0]),
+            )
+            cwords.append(
+                ConsensusWord(
+                    word=word,
+                    agreement=agreement,
+                    votes=votes,
+                    flagged=flagged,
+                    alternatives=alternatives,
+                )
+            )
+        if cwords:
+            lines.append(ConsensusLine(start=line.start, end=line.end, words=cwords))
+    return ConsensusResult(primary=primary.name, lines=lines, passes=passes)

--- a/unova/lyric-decipher/lyric_decipher/metadata.py
+++ b/unova/lyric-decipher/lyric_decipher/metadata.py
@@ -98,8 +98,9 @@ def lookup_published_lyrics(track: TrackInfo) -> ReferenceLyrics | None:
         return None
 
     def plausible(hit: dict) -> bool:
-        name = (hit.get("trackName") or "").lower()
-        return bool(name) and _norm(track.title) in _norm(name) or _norm(name) in _norm(track.title)
+        name = _norm(hit.get("trackName"))
+        title = _norm(track.title)
+        return bool(name) and (title in name or name in title)
 
     ranked = [h for h in hits if isinstance(h, dict) and plausible(h)]
     if not ranked:

--- a/unova/lyric-decipher/lyric_decipher/metadata.py
+++ b/unova/lyric-decipher/lyric_decipher/metadata.py
@@ -1,0 +1,129 @@
+"""Track metadata resolution and published-lyrics lookup.
+
+Two network helpers, both against open unauthenticated endpoints:
+
+- Spotify oEmbed (https://open.spotify.com/oembed) resolves a pasted track link
+  to a display title without needing API credentials. It never touches audio.
+- LRCLIB (https://lrclib.net) is an open, liberally licensed lyrics database.
+  We check it first so we only spend transcription effort on tracks whose
+  lyrics genuinely are not published anywhere.
+
+Both helpers fail soft: any network or parse error returns None so the
+pipeline can continue offline.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+
+USER_AGENT = "unova-lyric-decipher/0.1 (personal use)"
+DEFAULT_TIMEOUT = 15
+
+
+@dataclass
+class TrackInfo:
+    title: str | None = None
+    artist: str | None = None
+    spotify_url: str | None = None
+    source: str = "manual"
+
+    def slug(self) -> str:
+        base = " ".join(p for p in (self.artist, self.title) if p) or "unknown-track"
+        base = base.lower()
+        base = re.sub(r"[^a-z0-9]+", "-", base).strip("-")
+        return base[:60] or "unknown-track"
+
+    def display(self) -> str:
+        if self.artist and self.title:
+            return f"{self.title} — {self.artist}"
+        return self.title or self.artist or "unknown track"
+
+
+@dataclass
+class ReferenceLyrics:
+    source: str
+    plain: str | None = None
+    synced: str | None = None
+    instrumental: bool = False
+    detail: dict = field(default_factory=dict)
+
+
+def _get_json(url: str, timeout: int = DEFAULT_TIMEOUT):
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def resolve_spotify_track(url: str) -> TrackInfo | None:
+    """Resolve a Spotify track URL to title/artist via the public oEmbed endpoint.
+
+    oEmbed only exposes a display title (usually "Title" or "Title (mix)"), not
+    a separate artist field, so the artist may stay None and can be filled in
+    with --artist.
+    """
+    if "open.spotify.com" not in url:
+        return None
+    clean = url.split("?")[0]
+    oembed = "https://open.spotify.com/oembed?url=" + urllib.parse.quote(clean, safe="")
+    try:
+        data = _get_json(oembed)
+    except Exception:
+        return None
+    title = (data.get("title") or "").strip() or None
+    return TrackInfo(title=title, artist=None, spotify_url=clean, source="spotify-oembed")
+
+
+def lookup_published_lyrics(track: TrackInfo) -> ReferenceLyrics | None:
+    """Search LRCLIB for already-published lyrics for this track.
+
+    Returns the best hit, or None when nothing plausible is published — which
+    for this pack's target material (tiny artists, unreleased mixes) is the
+    common case and the signal to transcribe.
+    """
+    if not track.title:
+        return None
+    params = {"track_name": track.title}
+    if track.artist:
+        params["artist_name"] = track.artist
+    url = "https://lrclib.net/api/search?" + urllib.parse.urlencode(params)
+    try:
+        hits = _get_json(url)
+    except Exception:
+        return None
+    if not isinstance(hits, list) or not hits:
+        return None
+
+    def plausible(hit: dict) -> bool:
+        name = (hit.get("trackName") or "").lower()
+        return bool(name) and _norm(track.title) in _norm(name) or _norm(name) in _norm(track.title)
+
+    ranked = [h for h in hits if isinstance(h, dict) and plausible(h)]
+    if not ranked:
+        return None
+    best = ranked[0]
+    plain = best.get("plainLyrics") or None
+    synced = best.get("syncedLyrics") or None
+    instrumental = bool(best.get("instrumental"))
+    if not plain and not synced and not instrumental:
+        return None
+    return ReferenceLyrics(
+        source="lrclib",
+        plain=plain,
+        synced=synced,
+        instrumental=instrumental,
+        detail={
+            "id": best.get("id"),
+            "trackName": best.get("trackName"),
+            "artistName": best.get("artistName"),
+            "albumName": best.get("albumName"),
+            "duration": best.get("duration"),
+        },
+    )
+
+
+def _norm(text: str | None) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", (text or "").lower()).strip()

--- a/unova/lyric-decipher/lyric_decipher/output.py
+++ b/unova/lyric-decipher/lyric_decipher/output.py
@@ -1,0 +1,225 @@
+"""Run-folder outputs, following the unova runs/<timestamp>-<slug>/ convention.
+
+Each run writes:
+
+- lyrics.txt     clean reading copy; uncertain words marked [word?]
+- lyrics.lrc     synced lyrics (line-level timestamps) for players that scroll
+- lyrics.srt     subtitle form, handy for ear-checking in a video player
+- report.md      human review sheet: flagged words with timestamps + what the
+                 other passes heard instead
+- report.json    full machine-readable record of every pass and every word
+- reference.*    published lyrics, only when the lookup actually found some
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+from .consensus import ConsensusResult
+from .metadata import ReferenceLyrics, TrackInfo
+
+
+def make_run_dir(pack_root: Path, slug: str, now: dt.datetime | None = None) -> Path:
+    now = now or dt.datetime.now()
+    stamp = now.strftime("%Y%m%d-%H%M%S")
+    run_dir = pack_root / "runs" / f"{stamp}-{slug}"
+    run_dir.mkdir(parents=True, exist_ok=False)
+    latest = pack_root / "runs" / "latest"
+    try:
+        if latest.is_symlink() or latest.exists():
+            latest.unlink()
+        latest.symlink_to(run_dir.name)
+    except OSError:
+        pass  # symlinks are a convenience; never fail the run over them
+    return run_dir
+
+
+def _fmt_ts(seconds: float) -> str:
+    m, s = divmod(max(seconds, 0.0), 60)
+    return f"{int(m):02d}:{s:05.2f}"
+
+
+def _fmt_srt_ts(seconds: float) -> str:
+    total_ms = int(round(max(seconds, 0.0) * 1000))
+    h, rem = divmod(total_ms, 3_600_000)
+    m, rem = divmod(rem, 60_000)
+    s, ms = divmod(rem, 1000)
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def write_outputs(
+    run_dir: Path,
+    track: TrackInfo,
+    consensus: ConsensusResult,
+    reference: ReferenceLyrics | None,
+    *,
+    audio_notes: list[dict],
+    settings: dict,
+) -> dict[str, Path]:
+    written: dict[str, Path] = {}
+    header = track.display()
+    confidence = consensus.overall_confidence()
+    flagged = consensus.flagged_words()
+
+    # lyrics.txt — the reading copy
+    txt_lines = [
+        f"# {header}",
+        f"# deciphered {dt.date.today().isoformat()} · primary pass {consensus.primary}"
+        f" · overall confidence {confidence:.0%}",
+        "# words marked [like this?] need an ear-check — see report.md",
+        "",
+    ]
+    txt_lines += [line.marked_text() for line in consensus.lines]
+    written["lyrics.txt"] = _write(run_dir / "lyrics.txt", "\n".join(txt_lines) + "\n")
+
+    # lyrics.lrc — synced
+    lrc_lines = [f"[ti:{track.title or 'unknown'}]"]
+    if track.artist:
+        lrc_lines.append(f"[ar:{track.artist}]")
+    lrc_lines.append("[re:unova-lyric-decipher]")
+    for line in consensus.lines:
+        lrc_lines.append(f"[{_fmt_ts(line.start)}]{line.text}")
+    written["lyrics.lrc"] = _write(run_dir / "lyrics.lrc", "\n".join(lrc_lines) + "\n")
+
+    # lyrics.srt — for ear-checking in a video/audio player
+    srt_chunks = []
+    for i, line in enumerate(consensus.lines, 1):
+        srt_chunks.append(
+            f"{i}\n{_fmt_srt_ts(line.start)} --> {_fmt_srt_ts(line.end)}\n{line.marked_text()}\n"
+        )
+    written["lyrics.srt"] = _write(run_dir / "lyrics.srt", "\n".join(srt_chunks))
+
+    # report.md — the human review sheet
+    md = [
+        f"# Decipher report — {header}",
+        "",
+        f"- overall confidence: **{confidence:.0%}**",
+        f"- primary pass: `{consensus.primary}`",
+        f"- passes run: {len(consensus.passes)}",
+        f"- words flagged for ear-check: {len(flagged)} / {len(consensus.words)}",
+    ]
+    if reference:
+        md.append(
+            f"- published lyrics: **found on {reference.source}** — saved as reference; "
+            "compare before trusting the transcription"
+        )
+    else:
+        md.append("- published lyrics: none found (lookup came back empty)")
+    md += ["", "## Passes", ""]
+    md.append("| pass | detected language | avg word confidence |")
+    md.append("|---|---|---|")
+    for p in consensus.passes:
+        md.append(f"| `{p.name}` | {p.language} ({p.language_prob:.0%}) | {p.score():.0%} |")
+    md += ["", "## Words to ear-check", ""]
+    if flagged:
+        md.append("| time | heard | conf | agreement | other passes heard |")
+        md.append("|---|---|---|---|---|")
+        for cw in flagged:
+            alts = ", ".join(f"“{t}”×{n}" for t, n in cw.alternatives) or "—"
+            md.append(
+                f"| {_fmt_ts(cw.word.start)} | **{cw.word.text}** | {cw.word.prob:.0%} "
+                f"| {cw.agreement:.0%} of {cw.votes} | {alts} |"
+            )
+        md += [
+            "",
+            "Open the audio at each timestamp (lyrics.srt loads straight into a video "
+            "player) and settle these by ear; then edit lyrics.txt in place.",
+        ]
+    else:
+        md.append("Nothing flagged — every word cleared confidence and agreement checks.")
+    written["report.md"] = _write(run_dir / "report.md", "\n".join(md) + "\n")
+
+    # report.json — everything, machine-readable
+    payload = {
+        "track": {
+            "title": track.title,
+            "artist": track.artist,
+            "spotify_url": track.spotify_url,
+            "metadata_source": track.source,
+        },
+        "settings": settings,
+        "audio_variants": audio_notes,
+        "overall_confidence": confidence,
+        "primary_pass": consensus.primary,
+        "reference_lyrics_found": bool(reference),
+        "passes": [
+            {
+                "name": p.name,
+                "variant": p.variant,
+                "config": p.config,
+                "language": p.language,
+                "language_probability": p.language_prob,
+                "score": p.score(),
+                "lines": [
+                    {
+                        "start": line.start,
+                        "end": line.end,
+                        "text": line.text,
+                        "avg_logprob": line.avg_logprob,
+                        "no_speech_prob": line.no_speech_prob,
+                        "words": [
+                            {"start": w.start, "end": w.end, "text": w.text, "prob": w.prob}
+                            for w in line.words
+                        ],
+                    }
+                    for line in p.lines
+                ],
+            }
+            for p in consensus.passes
+        ],
+        "consensus": [
+            {
+                "start": line.start,
+                "end": line.end,
+                "text": line.text,
+                "words": [
+                    {
+                        "text": cw.word.text,
+                        "start": cw.word.start,
+                        "end": cw.word.end,
+                        "prob": cw.word.prob,
+                        "agreement": cw.agreement,
+                        "votes": cw.votes,
+                        "flagged": cw.flagged,
+                        "alternatives": [{"text": t, "count": n} for t, n in cw.alternatives],
+                    }
+                    for cw in line.words
+                ],
+            }
+            for line in consensus.lines
+        ],
+    }
+    written["report.json"] = _write(
+        run_dir / "report.json", json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    )
+
+    if reference:
+        if reference.synced:
+            written["reference.lrc"] = _write(run_dir / "reference.lrc", reference.synced + "\n")
+        if reference.plain:
+            written["reference.txt"] = _write(run_dir / "reference.txt", reference.plain + "\n")
+    return written
+
+
+def write_reference_only(run_dir: Path, track: TrackInfo, reference: ReferenceLyrics) -> dict[str, Path]:
+    written: dict[str, Path] = {}
+    if reference.synced:
+        written["reference.lrc"] = _write(run_dir / "reference.lrc", reference.synced + "\n")
+    if reference.plain:
+        written["reference.txt"] = _write(run_dir / "reference.txt", reference.plain + "\n")
+    note = {
+        "track": {"title": track.title, "artist": track.artist, "spotify_url": track.spotify_url},
+        "reference": {"source": reference.source, **reference.detail,
+                      "instrumental": reference.instrumental},
+    }
+    written["report.json"] = _write(
+        run_dir / "report.json", json.dumps(note, indent=2, ensure_ascii=False) + "\n"
+    )
+    return written
+
+
+def _write(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path

--- a/unova/lyric-decipher/lyric_decipher/output.py
+++ b/unova/lyric-decipher/lyric_decipher/output.py
@@ -25,6 +25,10 @@ def make_run_dir(pack_root: Path, slug: str, now: dt.datetime | None = None) -> 
     now = now or dt.datetime.now()
     stamp = now.strftime("%Y%m%d-%H%M%S")
     run_dir = pack_root / "runs" / f"{stamp}-{slug}"
+    suffix = 2
+    while run_dir.exists():
+        run_dir = pack_root / "runs" / f"{stamp}-{slug}-{suffix}"
+        suffix += 1
     run_dir.mkdir(parents=True, exist_ok=False)
     latest = pack_root / "runs" / "latest"
     try:

--- a/unova/lyric-decipher/lyric_decipher/transcribe.py
+++ b/unova/lyric-decipher/lyric_decipher/transcribe.py
@@ -1,0 +1,161 @@
+"""Multi-pass Whisper transcription via faster-whisper.
+
+One "pass" = one prepared audio variant transcribed under one decode config.
+Passes differ on purpose: sung vocals are far off Whisper's training
+distribution, so different variants/configs fail in *different* places, and
+the consensus stage exploits that disagreement to find the uncertain words.
+
+faster-whisper is imported lazily so the offline unit tests and `--lookup-only`
+runs never need the dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .audio import AudioVariant
+
+
+@dataclass
+class Word:
+    start: float
+    end: float
+    text: str
+    prob: float
+
+    @property
+    def mid(self) -> float:
+        return (self.start + self.end) / 2
+
+
+@dataclass
+class Line:
+    start: float
+    end: float
+    text: str
+    words: list[Word] = field(default_factory=list)
+    avg_logprob: float = 0.0
+    no_speech_prob: float = 0.0
+
+
+@dataclass
+class PassResult:
+    name: str
+    variant: str
+    config: str
+    language: str
+    language_prob: float
+    lines: list[Line] = field(default_factory=list)
+
+    @property
+    def words(self) -> list[Word]:
+        return [w for line in self.lines for w in line.words]
+
+    def score(self) -> float:
+        """Mean word probability, weighted by word duration; 0 when empty."""
+        words = self.words
+        if not words:
+            return 0.0
+        total_dur = sum(max(w.end - w.start, 0.05) for w in words)
+        return sum(w.prob * max(w.end - w.start, 0.05) for w in words) / total_dur
+
+
+@dataclass
+class DecodeConfig:
+    name: str
+    beam_size: int = 5
+    temperature: float | tuple[float, ...] = 0.0
+    condition_on_previous_text: bool = True
+
+
+DEFAULT_CONFIGS = [
+    DecodeConfig("beam5", beam_size=5, temperature=0.0),
+    DecodeConfig("beam8-nocond", beam_size=8, temperature=0.0, condition_on_previous_text=False),
+    DecodeConfig("sample", beam_size=1, temperature=(0.2, 0.4, 0.6)),
+]
+
+# Passes: every variant gets the solid beam pass; the best-quality variant
+# (last in the prepared list — vocals > enhanced > original) also gets the
+# alternate configs so disagreement data concentrates where audio is cleanest.
+
+
+def build_passes(variants: list[AudioVariant], extra_configs: int) -> list[tuple[AudioVariant, DecodeConfig]]:
+    plan: list[tuple[AudioVariant, DecodeConfig]] = []
+    for variant in variants:
+        plan.append((variant, DEFAULT_CONFIGS[0]))
+    best = variants[-1]
+    for cfg in DEFAULT_CONFIGS[1 : 1 + max(extra_configs, 0)]:
+        plan.append((best, cfg))
+    return plan
+
+
+def run_passes(
+    variants: list[AudioVariant],
+    *,
+    model_size: str = "small",
+    language: str | None = None,
+    extra_configs: int = 2,
+    initial_prompt: str | None = None,
+    device: str = "auto",
+    compute_type: str = "auto",
+    progress=lambda msg: None,
+) -> list[PassResult]:
+    from faster_whisper import WhisperModel
+
+    progress(f"loading Whisper model '{model_size}' ({device}/{compute_type})")
+    model = WhisperModel(model_size, device=device, compute_type=compute_type)
+
+    results: list[PassResult] = []
+    plan = build_passes(variants, extra_configs)
+    for i, (variant, cfg) in enumerate(plan, 1):
+        progress(f"pass {i}/{len(plan)}: {variant.name} × {cfg.name}")
+        segments, info = model.transcribe(
+            str(variant.path),
+            language=language,
+            beam_size=cfg.beam_size,
+            temperature=cfg.temperature,
+            condition_on_previous_text=cfg.condition_on_previous_text,
+            word_timestamps=True,
+            vad_filter=True,
+            vad_parameters={"min_silence_duration_ms": 350},
+            initial_prompt=initial_prompt,
+        )
+        lines: list[Line] = []
+        for seg in segments:
+            # faster-whisper hands back numpy scalars; coerce to native types
+            # here so everything downstream (json included) stays plain Python.
+            words = [
+                Word(start=float(w.start), end=float(w.end),
+                     text=w.word.strip(), prob=float(w.probability))
+                for w in (seg.words or [])
+                if w.word.strip()
+            ]
+            lines.append(
+                Line(
+                    start=float(seg.start),
+                    end=float(seg.end),
+                    text=seg.text.strip(),
+                    words=words,
+                    avg_logprob=float(seg.avg_logprob),
+                    no_speech_prob=float(seg.no_speech_prob),
+                )
+            )
+        results.append(
+            PassResult(
+                name=f"{variant.name}/{cfg.name}",
+                variant=variant.name,
+                config=cfg.name,
+                language=info.language,
+                language_prob=info.language_probability,
+                lines=lines,
+            )
+        )
+    return results
+
+
+def save_pass_audio_note(variants: list[AudioVariant]) -> list[dict]:
+    return [
+        {"name": v.name, "file": v.path.name, "description": v.description}
+        for v in variants
+    ]

--- a/unova/lyric-decipher/requirements.txt
+++ b/unova/lyric-decipher/requirements.txt
@@ -1,0 +1,9 @@
+# Core: CPU-friendly Whisper inference with word timestamps.
+faster-whisper>=1.0
+
+# Optional, for the highest-quality vocal isolation on dense mixes
+# (pulls PyTorch, ~2 GB — enable only if you want the --demucs variant):
+# demucs>=4.0
+
+# ffmpeg is a system dependency, not a pip package:
+#   macOS: brew install ffmpeg

--- a/unova/lyric-decipher/runs/.gitignore
+++ b/unova/lyric-decipher/runs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/unova/lyric-decipher/smoke/check_smoke.py
+++ b/unova/lyric-decipher/smoke/check_smoke.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Assert the smoke run produced outputs and recovered most of the known vocal."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+work = Path(sys.argv[1])
+expected_words = set(re.findall(r"[a-z']+", sys.argv[2].lower()))
+
+runs = sorted(p for p in (work / "runs").iterdir() if p.is_dir() and p.name != "latest")
+assert runs, "no run directory was created"
+run = runs[-1]
+
+for name in ("lyrics.txt", "lyrics.lrc", "lyrics.srt", "report.md", "report.json"):
+    assert (run / name).exists(), f"missing output: {name}"
+
+report = json.loads((run / "report.json").read_text())
+assert len(report["passes"]) >= 2, "expected at least two transcription passes"
+
+heard = set(re.findall(r"[a-z']+", (run / "lyrics.txt").read_text().lower()))
+stop = {"the", "a", "while", "away"}
+targets = expected_words - stop
+hits = targets & heard
+recall = len(hits) / len(targets)
+print(f"keyword recall: {len(hits)}/{len(targets)} ({recall:.0%}) — heard: {sorted(hits)}")
+assert recall >= 0.5, f"recall too low; missing {sorted(targets - heard)}"

--- a/unova/lyric-decipher/smoke/run_smoke.sh
+++ b/unova/lyric-decipher/smoke/run_smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# End-to-end smoke test on synthetic audio — no copyrighted material involved.
+# Needs: ffmpeg, espeak-ng, faster-whisper (downloads the tiny model on first run).
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+work="${LYRIC_DECIPHER_SMOKE_DIR:-${TMPDIR:-/tmp}/lyric-decipher-smoke}"
+rm -rf "$work"
+mkdir -p "$work"
+
+vocal_text="golden hour fades away while shadows dance across the water"
+
+echo "== synthesizing test song =="
+espeak-ng -v en-us -s 130 -p 55 -w "$work/vocal.wav" "$vocal_text"
+
+# Instrumental bed: an A-minor-ish drone plus brown noise, quiet enough that
+# the tiny model still has a fighting chance, loud enough to be a real mix.
+ffmpeg -y -v error \
+  -f lavfi -i "sine=frequency=220:duration=12" \
+  -f lavfi -i "sine=frequency=261.63:duration=12" \
+  -f lavfi -i "sine=frequency=329.63:duration=12" \
+  -f lavfi -i "anoisesrc=colour=brown:duration=12:amplitude=0.25" \
+  -filter_complex "amix=inputs=4:normalize=1" "$work/bed.wav"
+
+ffmpeg -y -v error -i "$work/vocal.wav" -i "$work/bed.wav" -filter_complex \
+  "[0]adelay=1200|1200[v];[1]volume=0.30[b];[v][b]amix=inputs=2:duration=first:normalize=0" \
+  -ac 2 "$work/song.wav"
+
+echo "== running the pipeline (tiny model) =="
+python3 "$here/../decipher.py" "$work/song.wav" \
+  --title "Smoke Test Song" --model tiny --language en \
+  --skip-lookup --out-root "$work"
+
+echo "== checking output =="
+python3 "$here/check_smoke.py" "$work" "$vocal_text"
+echo "smoke test passed"

--- a/unova/lyric-decipher/tests/conftest.py
+++ b/unova/lyric-decipher/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/unova/lyric-decipher/tests/test_consensus.py
+++ b/unova/lyric-decipher/tests/test_consensus.py
@@ -1,0 +1,76 @@
+from lyric_decipher.consensus import build_consensus, normalize_word
+from lyric_decipher.transcribe import Line, PassResult, Word
+
+
+def _mk_pass(name, word_specs, avg=0.9):
+    """word_specs: list of (start, end, text, prob) building one line per 4s window."""
+    words = [Word(start=s, end=e, text=t, prob=p) for s, e, t, p in word_specs]
+    line = Line(start=words[0].start, end=words[-1].end,
+                text=" ".join(w.text for w in words), words=words, avg_logprob=-0.2)
+    return PassResult(name=name, variant=name.split("/")[0], config="beam5",
+                      language="en", language_prob=0.99, lines=[line])
+
+
+def test_normalize_word_strips_punctuation_and_case():
+    assert normalize_word("Hello,") == "hello"
+    assert normalize_word("don't!") == "don't"
+    assert normalize_word("...") == ""
+
+
+def test_primary_is_highest_scoring_pass():
+    weak = _mk_pass("original/beam5", [(0, 1, "mumble", 0.3), (1, 2, "words", 0.3)])
+    strong = _mk_pass("enhanced/beam5", [(0, 1, "clear", 0.95), (1, 2, "words", 0.95)])
+    result = build_consensus([weak, strong])
+    assert result.primary == "enhanced/beam5"
+    assert result.lines[0].text == "clear words"
+
+
+def test_agreeing_confident_words_are_not_flagged():
+    a = _mk_pass("enhanced/beam5", [(0, 1, "golden", 0.9), (1, 2, "hour", 0.9)])
+    b = _mk_pass("original/beam5", [(0, 1, "golden", 0.8), (1, 2, "hour", 0.8)])
+    result = build_consensus([a, b])
+    assert [w.flagged for w in result.words] == [False, False]
+    assert all(w.agreement == 1.0 for w in result.words)
+
+
+def test_disagreement_flags_word_and_records_alternative():
+    a = _mk_pass("enhanced/beam5", [(0, 1, "chateau", 0.9), (1, 2, "nights", 0.9)])
+    b = _mk_pass("original/beam5", [(0, 1, "shadow", 0.7), (1, 2, "nights", 0.7)])
+    c = _mk_pass("vocals/beam5", [(0, 1, "shallow", 0.7), (1, 2, "nights", 0.7)])
+    result = build_consensus([a, b, c])
+    first = result.words[0]
+    assert first.flagged
+    assert first.agreement == 0.0
+    alt_texts = {t for t, _ in first.alternatives}
+    assert alt_texts == {"shadow", "shallow"}
+    assert not result.words[1].flagged
+
+
+def test_low_probability_word_is_flagged_even_when_unopposed():
+    a = _mk_pass("enhanced/beam5", [(0, 1, "whisper", 0.2)])
+    result = build_consensus([a])
+    assert result.words[0].flagged
+    assert result.words[0].votes == 0
+    assert result.words[0].agreement == 1.0
+
+
+def test_marked_text_wraps_flagged_words():
+    a = _mk_pass("enhanced/beam5", [(0, 1, "clear", 0.9), (1, 2, "mud", 0.1)])
+    result = build_consensus([a])
+    assert result.lines[0].marked_text() == "clear [mud?]"
+
+
+def test_word_matching_respects_time_windows():
+    # second pass heard a different word but 10s away — must not count as vote
+    a = _mk_pass("enhanced/beam5", [(0, 1, "alone", 0.9)])
+    b = _mk_pass("original/beam5", [(10, 11, "again", 0.9)])
+    result = build_consensus([a, b])
+    assert result.words[0].votes == 0
+    assert not result.words[0].flagged
+
+
+def test_overall_confidence_between_zero_and_one():
+    a = _mk_pass("enhanced/beam5", [(0, 1, "la", 0.9), (1, 2, "la", 0.4)])
+    b = _mk_pass("original/beam5", [(0, 1, "la", 0.8), (1, 2, "da", 0.5)])
+    result = build_consensus([a, b])
+    assert 0.0 < result.overall_confidence() <= 1.0

--- a/unova/lyric-decipher/tests/test_metadata.py
+++ b/unova/lyric-decipher/tests/test_metadata.py
@@ -1,0 +1,54 @@
+import lyric_decipher.metadata as metadata
+from lyric_decipher.metadata import TrackInfo, lookup_published_lyrics, resolve_spotify_track
+
+
+def test_track_slug_and_display():
+    t = TrackInfo(title="Chateau (elan)", artist="him's")
+    assert t.slug() == "him-s-chateau-elan"
+    assert t.display() == "Chateau (elan) — him's"
+    assert TrackInfo().display() == "unknown track"
+    assert TrackInfo().slug() == "unknown-track"
+
+
+def test_resolve_rejects_non_spotify_urls_without_network():
+    assert resolve_spotify_track("https://example.com/track/abc") is None
+
+
+def test_resolve_uses_oembed_title(monkeypatch):
+    monkeypatch.setattr(metadata, "_get_json", lambda url, timeout=15: {"title": "Chateau (elan)"})
+    info = resolve_spotify_track("https://open.spotify.com/track/7ewmdNM0LTB9MMomRmtFQY?si=x")
+    assert info.title == "Chateau (elan)"
+    assert info.spotify_url == "https://open.spotify.com/track/7ewmdNM0LTB9MMomRmtFQY"
+    assert info.source == "spotify-oembed"
+
+
+def test_lookup_requires_title():
+    assert lookup_published_lyrics(TrackInfo()) is None
+
+
+def test_lookup_returns_best_plausible_hit(monkeypatch):
+    hits = [
+        {"id": 9, "trackName": "Totally Different", "artistName": "x",
+         "plainLyrics": "nope"},
+        {"id": 1, "trackName": "Chateau (elan)", "artistName": "him's",
+         "plainLyrics": "some words", "syncedLyrics": "[00:01.00]some words",
+         "albumName": "Chateau (elan)", "duration": 94},
+    ]
+    monkeypatch.setattr(metadata, "_get_json", lambda url, timeout=15: hits)
+    ref = lookup_published_lyrics(TrackInfo(title="Chateau (elan)", artist="him's"))
+    assert ref is not None
+    assert ref.plain == "some words"
+    assert ref.detail["id"] == 1
+
+
+def test_lookup_handles_network_failure(monkeypatch):
+    def boom(url, timeout=15):
+        raise OSError("offline")
+
+    monkeypatch.setattr(metadata, "_get_json", boom)
+    assert lookup_published_lyrics(TrackInfo(title="Anything")) is None
+
+
+def test_lookup_ignores_empty_hits(monkeypatch):
+    monkeypatch.setattr(metadata, "_get_json", lambda url, timeout=15: [])
+    assert lookup_published_lyrics(TrackInfo(title="Anything")) is None

--- a/unova/lyric-decipher/tests/test_metadata.py
+++ b/unova/lyric-decipher/tests/test_metadata.py
@@ -52,3 +52,12 @@ def test_lookup_handles_network_failure(monkeypatch):
 def test_lookup_ignores_empty_hits(monkeypatch):
     monkeypatch.setattr(metadata, "_get_json", lambda url, timeout=15: [])
     assert lookup_published_lyrics(TrackInfo(title="Anything")) is None
+
+
+def test_lookup_rejects_hits_with_empty_or_unrelated_names(monkeypatch):
+    hits = [
+        {"id": 1, "trackName": "", "plainLyrics": "junk"},
+        {"id": 2, "trackName": "Completely Unrelated", "plainLyrics": "junk"},
+    ]
+    monkeypatch.setattr(metadata, "_get_json", lambda url, timeout=15: hits)
+    assert lookup_published_lyrics(TrackInfo(title="Chateau (elan)")) is None

--- a/unova/lyric-decipher/tests/test_output.py
+++ b/unova/lyric-decipher/tests/test_output.py
@@ -1,0 +1,81 @@
+import json
+
+from lyric_decipher.consensus import build_consensus
+from lyric_decipher.metadata import ReferenceLyrics, TrackInfo
+from lyric_decipher.output import make_run_dir, write_outputs, write_reference_only
+from lyric_decipher.transcribe import Line, PassResult, Word
+
+
+def _consensus():
+    words = [
+        Word(start=0.0, end=0.5, text="Golden", prob=0.9),
+        Word(start=0.5, end=1.0, text="hour", prob=0.9),
+        Word(start=1.2, end=1.6, text="fades", prob=0.2),
+    ]
+    line = Line(start=0.0, end=1.6, text="Golden hour fades", words=words, avg_logprob=-0.2)
+    p = PassResult(name="enhanced/beam5", variant="enhanced", config="beam5",
+                   language="en", language_prob=0.98, lines=[line])
+    return build_consensus([p])
+
+
+def test_make_run_dir_creates_stamped_dir_and_latest_symlink(tmp_path):
+    run_dir = make_run_dir(tmp_path, "himns-chateau")
+    assert run_dir.is_dir()
+    assert run_dir.name.endswith("-himns-chateau")
+    latest = tmp_path / "runs" / "latest"
+    assert latest.is_symlink()
+    assert (latest / ".").resolve() == run_dir.resolve()
+
+
+def test_write_outputs_produces_all_files(tmp_path):
+    track = TrackInfo(title="Chateau (elan)", artist="him's",
+                      spotify_url="https://open.spotify.com/track/x")
+    run_dir = make_run_dir(tmp_path, track.slug())
+    written = write_outputs(run_dir, track, _consensus(), None,
+                            audio_notes=[{"name": "enhanced"}],
+                            settings={"model": "small"})
+    assert set(written) == {"lyrics.txt", "lyrics.lrc", "lyrics.srt", "report.md", "report.json"}
+
+    txt = written["lyrics.txt"].read_text()
+    assert "Golden hour [fades?]" in txt
+    assert "Chateau (elan) — him's" in txt
+
+    lrc = written["lyrics.lrc"].read_text()
+    assert "[ti:Chateau (elan)]" in lrc
+    assert "[00:00.00]Golden hour fades" in lrc
+
+    srt = written["lyrics.srt"].read_text()
+    assert "00:00:00,000 --> 00:00:01,600" in srt
+
+    report = json.loads(written["report.json"].read_text())
+    assert report["track"]["artist"] == "him's"
+    assert report["consensus"][0]["words"][2]["flagged"] is True
+    assert report["reference_lyrics_found"] is False
+
+    md = written["report.md"].read_text()
+    assert "fades" in md and "Words to ear-check" in md
+
+
+def test_write_outputs_saves_reference_when_found(tmp_path):
+    track = TrackInfo(title="Known Song", artist="Someone")
+    run_dir = make_run_dir(tmp_path, track.slug())
+    ref = ReferenceLyrics(source="lrclib", plain="la la la", synced="[00:01.00]la la la")
+    written = write_outputs(run_dir, track, _consensus(), ref,
+                            audio_notes=[], settings={})
+    assert written["reference.txt"].read_text().strip() == "la la la"
+    assert written["reference.lrc"].read_text().startswith("[00:01.00]")
+
+
+def test_write_reference_only(tmp_path):
+    track = TrackInfo(title="Known Song", artist="Someone")
+    run_dir = make_run_dir(tmp_path, track.slug())
+    ref = ReferenceLyrics(source="lrclib", plain="words", detail={"id": 1})
+    written = write_reference_only(run_dir, track, ref)
+    assert "reference.txt" in written and "report.json" in written
+
+
+def test_run_dir_slug_sanitizes_names(tmp_path):
+    track = TrackInfo(title="Chateau (elan)!!", artist="him's")
+    assert track.slug() == "him-s-chateau-elan"
+    run_dir = make_run_dir(tmp_path, track.slug())
+    assert " " not in run_dir.name

--- a/unova/lyric-decipher/tests/test_output.py
+++ b/unova/lyric-decipher/tests/test_output.py
@@ -74,6 +74,16 @@ def test_write_reference_only(tmp_path):
     assert "reference.txt" in written and "report.json" in written
 
 
+def test_make_run_dir_survives_same_second_collision(tmp_path):
+    import datetime as dt
+
+    frozen = dt.datetime(2026, 8, 17, 12, 0, 0)
+    first = make_run_dir(tmp_path, "slug", now=frozen)
+    second = make_run_dir(tmp_path, "slug", now=frozen)
+    assert first != second
+    assert second.name.endswith("-slug-2")
+
+
 def test_run_dir_slug_sanitizes_names(tmp_path):
     track = TrackInfo(title="Chateau (elan)!!", artist="him's")
     assert track.slug() == "him-s-chateau-elan"


### PR DESCRIPTION
## What this adds

A new UNOVA pack, `unova/lyric-decipher/`: a local bot for deciphering lyrics that are genuinely hard to hear and not published anywhere (mumbled vocals, tiny artists, unreleased mixes). Motivating track: "Chateau (elan)" by him's — no lyrics exist on LRCLIB or anywhere public.

## How it works

1. **Metadata** — resolves a pasted Spotify track link to a title via the public oEmbed endpoint (metadata only; it never downloads audio from streaming services), or takes `--title/--artist` directly.
2. **Published-lyrics check** — searches LRCLIB first; if someone already transcribed the song it is saved as `reference.*` and no effort is wasted.
3. **Audio variants** — ffmpeg builds a vocal-focused variant (center-channel extraction + voice band-pass + gentle compression); `--demucs` optionally adds a true ML vocal stem.
4. **Multi-pass Whisper** — each variant is transcribed with word-level timestamps via faster-whisper; the best variant gets extra decode configs. Sung vocals make ASR fail in *different* places per pass, which is the signal the merge step needs.
5. **Consensus** — the strongest pass provides structure; every word is cross-checked against the other passes by time overlap. Uncertain/disputed words come out marked `[like this?]` with timestamps and the alternatives each pass heard, so only those seconds need an ear-check.

Outputs land in the standard `runs/<timestamp>-<slug>/` layout: `lyrics.txt`, synced `lyrics.lrc`, `lyrics.srt` (for ear-checking in a video player), `report.md` (review sheet), `report.json` (full machine-readable record).

## Testing

- 20 offline unit tests (consensus math, output formats, metadata resolution — no model or network needed): all passing.
- End-to-end smoke test (`smoke/run_smoke.sh`) synthesizes a fake song (espeak-ng vocal over a generated instrumental bed), runs the full pipeline with the `tiny` model, and checks keyword recall — passing at 71% recall with correct uncertainty flagging on the words it garbled.
- CLI error paths (`--lookup-only` miss, missing file, missing args) exercised manually.
- codespell clean with the repo config.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGapAeaN5qApLHd44dqndz)_